### PR TITLE
fix graphicspath for the template 

### DIFF
--- a/rapport.cls
+++ b/rapport.cls
@@ -28,7 +28,7 @@
 \RequirePackage{natbib}
 \RequirePackage{amsthm}
 \RequirePackage{xspace}
-\graphicspath{img/}
+\graphicspath{{./img/}}
 \def\@author{No authors given}
 \def\@supervisor{No supervisor given}
 \newcommand{\supervisor}[1]{\gdef\@supervisor{#1}}


### PR DESCRIPTION
il y avait un problème avec la commande \graphicspath{/img} ligne 31 dans rapport.cls